### PR TITLE
Changed request type to 'POST' on 'resend dcv email'

### DIFF
--- a/src/V1/Entities/DCV.php
+++ b/src/V1/Entities/DCV.php
@@ -62,6 +62,6 @@ class DCV extends Entity
      */
     public function resend(int $certificateId)
     {
-        return $this->getHttpClient()->request("ssl_certificates/{$certificateId}/resend_dcv");
+        return $this->getHttpClient()->request("ssl_certificates/{$certificateId}/resend_dcv", 'POST');
     }
 }


### PR DESCRIPTION
Leader SSL require 'POST' type request, docs:

**10. Resend DCV Email**

Resend validation email.
Endpoint

[http://api.leaderssl.com/api/v1/ssl_certificates/{certificate_id}/resend_dcv](http://api.leaderssl.com/api/v1/ssl_certificates/%7Bcertificate_id%7D/resend_dcv)
**Method**

POST